### PR TITLE
fix ndarray_backend_numpy.scalar_power()

### DIFF
--- a/python/needle/backend_ndarray/ndarray_backend_numpy.py
+++ b/python/needle/backend_ndarray/ndarray_backend_numpy.py
@@ -66,7 +66,7 @@ def scalar_div(a, val, out):
 
 
 def scalar_power(a, val, out):
-    out.array[:] = a.array ** power
+    out.array[:] = a.array ** val
 
 
 def ewise_maximum(a, b, out):


### PR DESCRIPTION
Fixed `ndarray_backend_numpy.scalar_power()` to use passed function argument