### PR TITLE
ndarray.__matmul__: bugfix in tiling

### DIFF
--- a/python/needle/backend_ndarray/ndarray.py
+++ b/python/needle/backend_ndarray/ndarray.py
@@ -491,7 +491,7 @@ class NDArray:
             def tile(a, tile):
                 return a.as_strided(
                     (a.shape[0] // tile, a.shape[1] // tile, tile, tile),
-                    (a.shape[1] * tile, tile, self.shape[1], 1),
+                    (a.shape[1] * tile, tile, a.shape[1], 1),
                 )
 
             t = self.device.__tile_size__

--- a/tests/test_ndarray.py
+++ b/tests/test_ndarray.py
@@ -296,7 +296,9 @@ matmul_dims = [(16, 16, 16),
     (72, 72, 72), 
     (72, 73, 74), 
     (74, 73, 72), 
-    (128, 128, 128)]
+    (128, 128, 128),
+    (8, 16, 8)
+]
 @pytest.mark.parametrize("device", _DEVICES, ids=["cpu", "cuda"])
 @pytest.mark.parametrize("m,n,p", matmul_dims)
 def test_matmul(m, n, p, device):


### PR DESCRIPTION
As mentioned in #4, the following line in `ndarray.__matmul__.tile()`:
```python
(a.shape[1] * tile, tile, self.shape[1], 1),
```
must be changed to:
```python
(a.shape[1] * tile, tile, a.shape[1], 1),
```

Otherwise `tile(other.compact(), t)` will return a matrix with wrong strides.

Adding `(8, 16, 8)` to `matmul_dims` params of `test_ndarray.test_matmul()` test function allows to demonstrate the issue - the test case fails if we use `tile()` function with wrong strides calculation. After I've fixed `tile()` function, this newly added test passed successfully.

By the way, we can't catch this error using `test_ndarray.test_matmul_tiled()` test function because it doesn't use the `tile()` function and creates input matrices already in shapes required for `nd.cpu().matmul_tiled()` function