### PR TITLE
Fix CMakeLists.txt for older cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(needle C CXX)
-cmake_policy(SET CMP0146 OLD)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.27")
+  cmake_policy(SET CMP0146 OLD)
+endif()
 
 # find correct version of Python
 execute_process(COMMAND python3-config --prefix


### PR DESCRIPTION
Policy only makes sense for new cmake. https://cmake.org/cmake/help/latest/policy/CMP0146.html
This enables building on my ub22