### PR TITLE
Update ndarray.py, fix the tile function here.

### DIFF
--- a/python/needle/backend_ndarray/ndarray.py
+++ b/python/needle/backend_ndarray/ndarray.py
@@ -508,7 +508,7 @@ class NDArray:
             def tile(a, tile):
                 return a.as_strided(
                     (a.shape[0] // tile, a.shape[1] // tile, tile, tile),
-                    (a.shape[1] * tile, tile, self.shape[1], 1),
+                    (a.shape[1] * tile, tile, a.shape[1], 1),
                 )
 
             t = self.device.__tile_size__


### PR DESCRIPTION
This is a bug when invoking tile function in __matmul__, though the function is never called in the test file which causes that you can still pass the test.